### PR TITLE
[긴급]SharedPreference getLocation 수정

### DIFF
--- a/app/src/main/java/com/depromeet/baton/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/depromeet/baton/util/SharedPreferenceManager.kt
@@ -51,8 +51,16 @@ class BatonSpfManager@Inject constructor(@ApplicationContext context: Context){
     }
 
     fun getLocation():LatLng{
-        val latLng :LatLng = LatLng(mSharedPreferences.getFloat("latitude",0F).toDouble(),mSharedPreferences.getFloat("latitude",0F).toDouble())
+        val latLng  = LatLng(mSharedPreferences.getFloat("latitude",0F).toDouble(),mSharedPreferences.getFloat("longitude",0F).toDouble())
         return latLng
+    }
+
+    fun getMyLongitude(): Float{
+        return mSharedPreferences.getFloat("longitude",0F)
+    }
+
+    fun getMyLatitude(): Float{
+        return mSharedPreferences.getFloat("latitude",0F)
     }
 
 


### PR DESCRIPTION
### 문제
LatLng 만드는 과정에서 latitude를 두번 저장하고 있었음 

[수정전]
```
 fun getLocation():LatLng{
        val latLng  = LatLng(mSharedPreferences.getFloat("latitude",0F).toDouble(),mSharedPreferences.getFloat("latitude",0F).toDouble())
        return latLng
    }
```


[수정후]
```
 fun getLocation():LatLng{
        val latLng  = LatLng(mSharedPreferences.getFloat("latitude",0F).toDouble(),mSharedPreferences.getFloat("longitude",0F).toDouble())
        return latLng
    }
```