### PR TITLE
gpsConverter 추가

### DIFF
--- a/app/src/main/java/com/depromeet/baton/presentation/ui/address/view/SearchAddressActivity.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/address/view/SearchAddressActivity.kt
@@ -14,6 +14,7 @@ import com.depromeet.baton.presentation.ui.address.SearchAddressAdapter
 import com.depromeet.baton.presentation.ui.address.viewmodel.SearchAddressViewModel
 import com.depromeet.baton.presentation.ui.address.model.AddressInfo
 import com.depromeet.baton.util.BatonSpfManager
+import com.depromeet.baton.util.gpsConverter
 import com.depromeet.bds.component.BdsSearchBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -53,8 +54,6 @@ class SearchAddressActivity : BaseActivity<ActivitySearchAddressBinding>(R.layou
 
     }
 
-
-
     private  fun setObserver() {
         searchAddressViewModel.searchAddress("")
         binding.searchAddressEt.textListener= object : BdsSearchBar.TextListener {
@@ -70,7 +69,6 @@ class SearchAddressActivity : BaseActivity<ActivitySearchAddressBinding>(R.layou
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 searchAddressViewModel.items.collect{
-                    Timber.e("NewItem!!!")
                     if(!it.isEmpty()){
                         listAdapter.submitList(it)
                     }
@@ -91,6 +89,8 @@ class SearchAddressActivity : BaseActivity<ActivitySearchAddressBinding>(R.layou
 
     private fun listItemClicked(item : AddressInfo){
         spfManager.saveAddress(item.roadAddress, item.address)
+        spfManager.saveLocation(gpsConverter(this,item.roadAddress))
+
         val intent = Intent(this, MyLocationDetailActivity::class.java)
         startActivity(intent)
     }

--- a/app/src/main/java/com/depromeet/baton/presentation/ui/address/viewmodel/SearchAddressViewModel.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/address/viewmodel/SearchAddressViewModel.kt
@@ -52,7 +52,6 @@ class SearchAddressViewModel @Inject constructor(
                             _uiState.value= (UIState.HasData)
                         }
                         is SearchItem.Empty -> {
-                            Timber.e("검색결과 없음")
                             _uiState.value= (UIState.NoData)
                         }
                     }

--- a/app/src/main/java/com/depromeet/baton/presentation/ui/detail/TicketDetailActivity.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/detail/TicketDetailActivity.kt
@@ -148,7 +148,6 @@ class TicketDetailActivity : BaseActivity<ActivityTicketDetailBinding>(R.layout.
                     //TODO showChatBottom
                 }
                 DetailViewEvent.EventClickLike->{
-                    Timber.e( viewModel.ticketState.value!!.ticket.isLikeTicket.toString())
                    if(viewModel.ticketState.value!!.ticket.isLikeTicket)
                        this@TicketDetailActivity.BdsToast("관심 상품이 등록되었습니다.",binding.ticketDetailFooter.top).show()
                     binding.ticketDetailLikeBtn.toggle()

--- a/app/src/main/java/com/depromeet/baton/util/gpsConverter.kt
+++ b/app/src/main/java/com/depromeet/baton/util/gpsConverter.kt
@@ -1,0 +1,22 @@
+package com.depromeet.baton.util
+
+import android.content.Context
+import android.location.Address
+import android.location.Geocoder
+import com.naver.maps.geometry.LatLng
+import timber.log.Timber
+
+fun gpsConverter(context : Context, addressQuery : String) : LatLng {
+    val coder = Geocoder(context)
+   val result= runCatching {
+        val address = coder.getFromLocationName(addressQuery, 1)
+        if(address.isEmpty()) throw NullPointerException("좌표를 찾을 수 없습니다")
+        val location: Address = address[0]
+        LatLng(location.latitude, location.longitude)
+    }.onFailure  {
+        e-> Timber.e(e.message)
+    }.getOrDefault(
+        LatLng(0.0,0.0)
+    )
+    return result
+}

--- a/map_module/src/main/java/com/depromeet/baton/map/data/dataSource/GPSDataSource.kt
+++ b/map_module/src/main/java/com/depromeet/baton/map/data/dataSource/GPSDataSource.kt
@@ -23,7 +23,6 @@ class GPSDataSource @Inject constructor (applicationContext: Context){
     fun getLocation() : Flow<LocationModel> = callbackFlow {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
-                Timber.e("get => ${result.lastLocation}")
                 for ((i, location) in result.locations.withIndex()) {
                     trySend(LocationModel(result.lastLocation))
                 }

--- a/map_module/src/main/java/com/depromeet/baton/map/data/repositoryImpl/AddressRepositoryImpl.kt
+++ b/map_module/src/main/java/com/depromeet/baton/map/data/repositoryImpl/AddressRepositoryImpl.kt
@@ -48,9 +48,7 @@ class AddressRepositoryImpl  @Inject constructor(
     private fun checkApiResult(_latitude : Double,  _longitude :Double,request :NetworkResult<KakaoGeoResponse>) :  NetworkResult<LocationEntity > {
      return if(request.data?.meta!!.total_count ==0 ) NetworkResult.Error("위치정보를 찾을 수 없습니다")
      else {
-
             val result= KakaoGeoModel(_latitude,_longitude,request)
-            Timber.e(result.mapToDomain().address.roadAddress)
             NetworkResult.Success<LocationEntity>(result.mapToDomain())
         }
     }


### PR DESCRIPTION
### 구현사항
addressQuery 에 도로명주소를 넣어 해당 주소의 LatLng(latitude, longitude) 를 얻는다
repository 부분에 추가해 검색 item 마다 location을  추가하려 했으나 처리 속도가 느려 로딩이 길어짐
-> 선택하지 않은 item 에는 불필요한 정보 & 로딩 시간 때문에 선택시 호출하여 변환하도록 함


```kotlin
fun gpsConverter(context : Context, addressQuery : String) : LatLng {
    val coder = Geocoder(context)
   val result= runCatching {
        val address = coder.getFromLocationName(addressQuery, 1)
        if(address.isEmpty()) throw NullPointerException("좌표를 찾을 수 없습니다")
        val location: Address = address[0]
        LatLng(location.latitude, location.longitude)
    }.onFailure  {
        e-> Timber.e(e.message)
    }.getOrDefault(
        LatLng(0.0,0.0)
    )
    return result
}

```
### SearchAddressActivity 적용 예제 ( recyclerview 아이템 선택 시)

```kotlin

 private fun listItemClicked(item : AddressInfo){
        spfManager.saveAddress(item.roadAddress, item.address)
        spfManager.saveLocation(gpsConverter(this,item.roadAddress))

        val intent = Intent(this, MyLocationDetailActivity::class.java)
        startActivity(intent)
    }
```

