### PR TITLE
회원가입에 나온 QA 이슈 대응

### DIFF
--- a/app/src/main/java/com/depromeet/baton/presentation/ui/sign/AddAccountActivity.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/sign/AddAccountActivity.kt
@@ -1,8 +1,10 @@
 package com.depromeet.baton.presentation.ui.sign
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcelable
 import android.text.Editable
 import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
@@ -18,7 +20,15 @@ import com.depromeet.baton.presentation.util.RegexConstant
 import com.depromeet.bds.component.BdsToast
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+
+@Parcelize
+data class SignAccount(
+    val name: String,
+    val bank: String,
+    val account: String,
+) : Parcelable
 
 class AddAccountActivity : BaseActivity<ActivityAddAccountBinding>(R.layout.activity_add_account) {
 
@@ -30,7 +40,6 @@ class AddAccountActivity : BaseActivity<ActivityAddAccountBinding>(R.layout.acti
 
         binding.appbar.setOnBackwardClick { onBackPressed() }
 
-
         viewModel.uiState
             .flowWithLifecycle(lifecycle)
             .onEach { uiState -> binding.uiState = uiState }
@@ -40,12 +49,20 @@ class AddAccountActivity : BaseActivity<ActivityAddAccountBinding>(R.layout.acti
             .flowWithLifecycle(lifecycle)
             .onEach(::handleViewEvents)
             .launchIn(lifecycleScope)
+        val account = intent.getParcelableExtra<SignAccount>(ACCOUNT)
+        viewModel.setAccount(account)
+        binding.etAccount.setText(account?.account)
+        binding.etName.setText(account?.name)
     }
 
     private fun handleViewEvents(viewEvents: List<ViewEvent>) {
         viewEvents.firstOrNull()?.let { viewEvent ->
             when (viewEvent) {
-                ViewEvent.AddAccountDone -> {
+                is ViewEvent.AddAccountDone -> {
+                    setResult(Activity.RESULT_OK, Intent().apply {
+                        putExtra(RESULT_ARGS, viewEvent.account)
+                    })
+
                     // do something
                     this.BdsToast("계좌가 등록됐어요.").show()
                     finish()
@@ -58,28 +75,37 @@ class AddAccountActivity : BaseActivity<ActivityAddAccountBinding>(R.layout.acti
         }
     }
 
-    private fun showBankBottom(){
-        val list =  resources.getStringArray(R.array.bank_items).map {
-            BottomMenuItem(it, it==viewModel.uiState.value.bank)
+    private fun showBankBottom() {
+        val list = resources.getStringArray(R.array.bank_items).map {
+            BottomMenuItem(it, it == viewModel.uiState.value.bank)
         }
         val bottom =
-            BottomSheetFragment.newInstance("은행선택",list, BottomSheetFragment.CHECK_ITEM_VIEW,object:
-                BottomSheetFragment.Companion.OnItemClick {
-                override fun onSelectedItem(selected: BottomMenuItem, pos: Int) {
-                    viewModel.handleBankSelected(selected.listItem!!)
-                }
-            })
-        bottom.show(supportFragmentManager,null)
+            BottomSheetFragment.newInstance(
+                "은행선택",
+                list,
+                BottomSheetFragment.CHECK_ITEM_VIEW,
+                object :
+                    BottomSheetFragment.Companion.OnItemClick {
+                    override fun onSelectedItem(selected: BottomMenuItem, pos: Int) {
+                        viewModel.handleBankSelected(selected.listItem!!)
+                    }
+                })
+        bottom.show(supportFragmentManager, null)
     }
 
     companion object {
-        fun start(context: Context) {
-            val intent = Intent(context, AddAccountActivity::class.java)
-            context.startActivity(intent)
+        private const val ACCOUNT = "account"
+        const val RESULT_ARGS = "result_args"
+
+        fun intent(context: Context, signAccount: SignAccount?): Intent {
+            return Intent(context, AddAccountActivity::class.java).apply {
+                putExtra(ACCOUNT, signAccount)
+            }
         }
     }
 }
 
+//TODO: validation 적용하기
 data class AddAccountUiState(
     val name: String,
     val bank: String,
@@ -88,12 +114,12 @@ data class AddAccountUiState(
     val onBankSelected: (String) -> Unit,
     val onAccountChanged: (Editable?) -> Unit,
     val onBankSelectionClick: () -> Unit,
-    val onClickSubmit : () -> Unit
+    val onClickSubmit: () -> Unit
 ) {
     private val isNameValid = name.isNotBlank() && RegexConstant.ONLY_COMPLETE_HANGLE.matches(name)
 
-    //BEAN: 일단 계좌 번호 길이 13으루
-    private val isAccountValid = account.length == 13
+    //BEAN: 일단 무조건 통과로
+    private val isAccountValid = true
 
     val nameErrorReason = if (isNameValid) null else "올바른 예금주명을 입력해주세요."
     val accountErrorReason = if (isAccountValid) null else "올바른 계좌번호를 입력해주세요."
@@ -123,6 +149,16 @@ class AddAccountViewModel @Inject constructor() : BaseViewModel() {
         )
     }
 
+    fun setAccount(account: SignAccount?) {
+        _uiState.update {
+            it.copy(
+                name = account?.name.orEmpty(),
+                bank = account?.bank.orEmpty(),
+                account = account?.account.orEmpty(),
+            )
+        }
+    }
+
     private fun handleNameChanged(editable: Editable?) {
         _uiState.update { it.copy(name = editable.toString()) }
     }
@@ -140,11 +176,20 @@ class AddAccountViewModel @Inject constructor() : BaseViewModel() {
         addViewEvent(ViewEvent.OpenBankSelection(currentBank))
     }
 
-    private fun submit(){
-        addViewEvent(ViewEvent.AddAccountDone)
+    private fun submit() {
+        makeAccount()?.let { addViewEvent(ViewEvent.AddAccountDone(it)) }
     }
 
+    private fun makeAccount(): SignAccount? {
+        val state = _uiState.value
 
+        val name = state.name
+        val bank = state.bank
+        val account = state.account
+
+        if (name.isBlank() || bank.isBlank() || account.isBlank()) return null
+        return SignAccount(name, bank, account)
+    }
 
     private fun addViewEvent(viewEvent: ViewEvent) {
         _viewEvents.update { it + viewEvent }
@@ -155,18 +200,7 @@ class AddAccountViewModel @Inject constructor() : BaseViewModel() {
     }
 
     sealed interface ViewEvent {
-        object AddAccountDone : ViewEvent
+        data class AddAccountDone(val account: SignAccount) : ViewEvent
         data class OpenBankSelection(val selectedBank: String) : ViewEvent
-    }
-
-    companion object {
-        val supportedBanks = listOf(
-            "NH농협은행",
-            "KB국민은행",
-            "카카오뱅크",
-            "신한은행",
-            "우리은행",
-            // and more ...
-        )
     }
 }

--- a/app/src/main/java/com/depromeet/baton/presentation/ui/sign/SignUpFragment.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/sign/SignUpFragment.kt
@@ -140,6 +140,11 @@ class SignUpViewModel @Inject constructor(
             name = source.name.value
             nickname = source.nickName.value.takeIf { it.isNotBlank() } ?: args.nickname
             phoneNumber = source.phoneNumber.value
+            account = source.account?.run {
+                SignUpKakaoRequest.Account(
+                    name, bank, account
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/depromeet/baton/presentation/ui/sign/SignUpFragment.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/sign/SignUpFragment.kt
@@ -137,9 +137,9 @@ class SignUpViewModel @Inject constructor(
     fun remember(infoViewModel: SignUpInfoViewModel) {
         val source = infoViewModel.uiState.value
         builder.apply {
-            name = source.name
-            nickname = source.nickName.takeIf { it.isNotBlank() } ?: args.nickname
-            phoneNumber = source.phoneNumber
+            name = source.name.value
+            nickname = source.nickName.value.takeIf { it.isNotBlank() } ?: args.nickname
+            phoneNumber = source.phoneNumber.value
         }
     }
 

--- a/app/src/main/java/com/depromeet/baton/presentation/ui/sign/Validation.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/ui/sign/Validation.kt
@@ -1,0 +1,7 @@
+package com.depromeet.baton.presentation.ui.sign
+
+data class Validation(
+    val value: String = "",
+    val errorReason: String? = null,
+    val isValidating: Boolean = false
+)

--- a/app/src/main/java/com/depromeet/baton/presentation/util/BindingAdapters.kt
+++ b/app/src/main/java/com/depromeet/baton/presentation/util/BindingAdapters.kt
@@ -86,6 +86,11 @@ fun setBdsTag(view: BdsTag, text: String?) {
     if (text != null) view.text = text
 }
 
+@BindingAdapter("bds_text")
+fun setBdsTag(view: BdsButton, text: String?) {
+    view.setText(text)
+}
+
 @BindingAdapter("isChecked")
 fun setBdsCheckbox(view: BdsCheckbox, isChecked: Boolean) {
     view.isChecked = isChecked

--- a/app/src/main/res/layout/activity_add_account.xml
+++ b/app/src/main/res/layout/activity_add_account.xml
@@ -48,6 +48,7 @@
                         app:bds_label="예금주">
 
                         <EditText
+                            android:id="@+id/et_name"
                             style="@style/Widget.Bds.TextFieldInnerEditText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
@@ -82,6 +83,7 @@
                         app:bds_label="계좌번호">
 
                         <EditText
+                            android:id="@+id/et_account"
                             style="@style/Widget.Bds.TextFieldInnerEditText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_add_account.xml
+++ b/app/src/main/res/layout/activity_add_account.xml
@@ -44,7 +44,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="24dp"
-                        app:bds_error_message="@{uiState.nameErrorReason}"
+                        app:bds_error_message="@{uiState.name.errorReason}"
                         app:bds_label="예금주">
 
                         <EditText
@@ -79,7 +79,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="24dp"
-                        app:bds_error_message="@{uiState.accountErrorReason}"
+                        app:bds_error_message="@{uiState.account.errorReason}"
                         app:bds_label="계좌번호">
 
                         <EditText

--- a/app/src/main/res/layout/fragment_sign_up_info.xml
+++ b/app/src/main/res/layout/fragment_sign_up_info.xml
@@ -53,7 +53,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     app:bds_error_message="@{uiState.nickNameErrorReason}"
-                    app:bds_label="닉네임 (선택)">
+                    app:bds_label="닉네임">
 
                     <EditText
                         style="@style/Widget.Bds.TextFieldInnerEditText"

--- a/app/src/main/res/layout/fragment_sign_up_info.xml
+++ b/app/src/main/res/layout/fragment_sign_up_info.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -82,13 +83,27 @@
                         android:inputType="phone" />
                 </com.depromeet.bds.component.BdsComponentTextField>
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="24dp"
-                    android:text="계좌정보 (선택)"
-                    android:textAppearance="?body3"
-                    android:textColor="?grey_scale60" />
+                    android:layout_marginTop="24dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="계좌정보 (선택)"
+                        android:textAppearance="?body3"
+                        android:textColor="?grey_scale60" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:text="입력완료"
+                        android:textAppearance="?caption2"
+                        android:textColor="?success"
+                        app:isVisible="@{uiState.account != null}" />
+                </LinearLayout>
 
                 <TextView
                     android:layout_width="match_parent"
@@ -104,7 +119,8 @@
                     android:layout_marginTop="6dp"
                     android:onClick="@{_ -> uiState.onAddAccountClick.invoke()}"
                     android:theme="@style/Theme.Bds.TertiaryButton.Large"
-                    app:bds_text="추가하기" />
+                    app:bds_text="@{uiState.accountText}"
+                    tools:bds_text="추가하기" />
 
             </LinearLayout>
         </ScrollView>

--- a/app/src/main/res/layout/fragment_sign_up_info.xml
+++ b/app/src/main/res/layout/fragment_sign_up_info.xml
@@ -35,7 +35,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    app:bds_error_message="@{uiState.nameErrorReason}"
+                    app:bds_error_message="@{uiState.name.errorReason}"
                     app:bds_helper_message="이름은 다시 수정할 수 없으니 정확하게 입력해주세요!"
                     app:bds_helper_textColor="?information"
                     app:bds_label="이름">
@@ -52,7 +52,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    app:bds_error_message="@{uiState.nickNameErrorReason}"
+                    app:bds_error_message="@{uiState.nickName.errorReason}"
                     app:bds_label="닉네임">
 
                     <EditText
@@ -67,7 +67,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    app:bds_error_message="@{uiState.phoneNumberErrorReason}"
+                    app:bds_error_message="@{uiState.phoneNumber.errorReason}"
                     app:bds_helper_message="회원님의 정확한 번호를 입력해주세요."
                     app:bds_helper_textColor="?information"
                     app:bds_label="휴대폰 번호">

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -17,10 +17,14 @@
         android:orientation="vertical"
         tools:ignore="HardcodedText">
 
+        <View
+            android:layout_width="1px"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="96dp"
             android:layout_marginBottom="2dp"
             android:text="안쓰는 헬스 회원권, "
             android:textAlignment="center"
@@ -30,27 +34,26 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="30dp"
+            android:layout_marginBottom="3dp"
             android:text="내 근처에서 바통터치!"
             android:textAlignment="center"
             android:textAppearance="?display4"
             android:textColor="?wh100" />
 
         <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="280dp"
+            android:layout_height="280dp"
             android:layout_gravity="center"
             android:src="@drawable/ic_ig_welcome" />
 
         <View
             android:layout_width="1px"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_height="30dp" />
 
         <com.depromeet.bds.component.BdsLinearLayout
             android:id="@+id/button_kakao"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="48dp"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="12dp"
@@ -69,6 +72,12 @@
                 app:drawableStartCompat="@drawable/ig_kakao" />
         </com.depromeet.bds.component.BdsLinearLayout>
 
+        <View
+            android:layout_width="1px"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <!-- FIXME: 네이버 로그인 도입 전 까지는 블락 -->
         <com.depromeet.bds.component.BdsLinearLayout
             android:id="@+id/button_naver"
             android:layout_width="match_parent"
@@ -79,6 +88,7 @@
             android:gravity="center"
             android:onClick="@{_ -> uiState.onNaverClick.invoke()}"
             android:padding="12dp"
+            android:visibility="gone"
             app:bdsBackgroundColor="?wh100"
             app:bdsBorderColor="?grey_scale40"
             app:bdsBorderWidth="1dp"

--- a/bds/src/main/java/com/depromeet/bds/component/BdsButton.kt
+++ b/bds/src/main/java/com/depromeet/bds/component/BdsButton.kt
@@ -49,7 +49,7 @@ class BdsButton @JvmOverloads constructor(
         }
     }
 
-    fun setText(text:String){
+    fun setText(text:String?){
         binding.tvText.text=text
     }
 }

--- a/bds/src/main/java/com/depromeet/bds/component/BdsComponentTextField.kt
+++ b/bds/src/main/java/com/depromeet/bds/component/BdsComponentTextField.kt
@@ -1,18 +1,17 @@
 package com.depromeet.bds.component
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import com.depromeet.bds.R
 import com.depromeet.bds.databinding.BdsComponentTextFieldBinding
-import com.depromeet.bds.utils.setTextAppearanceCompat
 
 // 자식으로 EditText 를 받고 거기에 위임하자.
 // EditText 관련 안드로이드 서포트 동작을 전부 오버라이드 하는 것은 미친 짓임.
@@ -36,41 +35,10 @@ class BdsComponentTextField @JvmOverloads constructor(
             field = value
         }
 
-    var errorMessage: String? = null
-        private set(value) {
-            if (field == value) return
-
-            binding.txtError.isVisible = !value.isNullOrBlank()
-            binding.txtError.text = value
-
-            field = value
-
-            refreshDrawableState()
-        }
-
-    var successMessage: String? = null
-        private set(value) {
-            if (field == value) return
-
-            binding.txtSuccess.isVisible = !value.isNullOrBlank()
-            binding.txtSuccess.text = value
-
-            field = value
-
-        }
-
     var helperMessage: String? = null
-        private set(value) {
-            if (field == value) return
-
-            binding.txtHelper.isVisible = !value.isNullOrBlank()
-            binding.txtHelper.text = value
-
-            field = value
-        }
 
     val isError: Boolean
-        get() = !errorMessage.isNullOrBlank()
+        get() = !binding.txtError.text.isNullOrBlank()
 
     init {
         val layoutInflater = LayoutInflater.from(context)
@@ -84,12 +52,12 @@ class BdsComponentTextField @JvmOverloads constructor(
         ) {
             getString(R.styleable.BdsComponentTextField_bds_label)
                 .also { label = it }
-            getString(R.styleable.BdsComponentTextField_bds_success_message)
-                .also { setSuccess(it) }
-            getString(R.styleable.BdsComponentTextField_bds_error_message)
-                .also { setError(it) }
-            getString(R.styleable.BdsComponentTextField_bds_helper_message)
-                .also { helperMessage = it }
+
+            val error = getString(R.styleable.BdsComponentTextField_bds_error_message)
+            val success = getString(R.styleable.BdsComponentTextField_bds_success_message)
+            helperMessage = getString(R.styleable.BdsComponentTextField_bds_helper_message)
+            updateDescriptionText(error, success, helperMessage)
+
             getColorStateList(R.styleable.BdsComponentTextField_bds_helper_textColor)
                 .also { colorStateList ->
                     colorStateList?.let { binding.txtHelper.setTextColor(it) }
@@ -98,33 +66,12 @@ class BdsComponentTextField @JvmOverloads constructor(
 
     }
 
-
-    fun clearStatus() {
-        errorMessage = null
-        successMessage = null
-    }
-
     fun setSuccess(message: String?) {
-        errorMessage = null
-        successMessage = message
+        updateDescriptionText(success = message)
     }
 
     fun setError(message: String?) {
-        successMessage = null
-        errorMessage = message
-    }
-
-    private fun findInnerEditText(viewGroup: ViewGroup?): EditText? {
-        if (viewGroup == null) return null
-
-        for (child in viewGroup.children) {
-            if (child is EditText) return child
-            else if (child is ViewGroup) {
-                findInnerEditText(child)
-                    ?.let { return it }
-            }
-        }
-        return null
+        updateDescriptionText(error = message)
     }
 
     override fun onFinishInflate() {
@@ -142,8 +89,40 @@ class BdsComponentTextField @JvmOverloads constructor(
             binding.containerInnerText.addView(
                 innerEditText,
                 0,
-                LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).apply { weight = 1f }
+                LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).apply {
+                    weight = 1f
+                }
             )
+        }
+    }
+
+    private fun updateDescriptionText(
+        error: String? = null,
+        success: String? = null,
+        helper: String? = helperMessage
+    ) {
+        fun TextView.clear() {
+            this.isVisible = false
+            this.text = null
+        }
+
+        binding.txtError.clear()
+        binding.txtSuccess.clear()
+        binding.txtHelper.clear()
+
+        when {
+            !error.isNullOrBlank() -> {
+                binding.txtError.isVisible = true
+                binding.txtError.text = error
+            }
+            !success.isNullOrBlank() -> {
+                binding.txtSuccess.isVisible = true
+                binding.txtSuccess.text = success
+            }
+            !helper.isNullOrBlank() -> {
+                binding.txtHelper.isVisible = true
+                binding.txtHelper.text = helper
+            }
         }
     }
 
@@ -157,5 +136,18 @@ class BdsComponentTextField @JvmOverloads constructor(
 
     companion object {
         private val ERROR_STATE_SET = intArrayOf(R.attr.state_error)
+
+        private fun findInnerEditText(viewGroup: ViewGroup?): EditText? {
+            if (viewGroup == null) return null
+
+            for (child in viewGroup.children) {
+                if (child is EditText) return child
+                else if (child is ViewGroup) {
+                    findInnerEditText(child)
+                        ?.let { return it }
+                }
+            }
+            return null
+        }
     }
 }


### PR DESCRIPTION
- 입력 이후 바로 에러 체크하는 게 아니라 1초 내에 다른 입력이 없을 때 에러 노출하는 Validation을 `회원가입 정보`, `계좌 정보 입력 `화면에 도입
- 네이버 로그인 UI 제거 및 Welcome 화면 UI 수정
- BdsTextField error, success, helper 문구는 셋 중 하나만 노출되도록 수정